### PR TITLE
fix `truncated packet`, rig up PyO3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ rust-version = "1.56.0"
 authors = ["Fabio Valentini <decathorpe@gmail.com>"]
 exclude = ["/rustfmt.toml"]
 
+[lib]
+name = "mitmproxy_wireguard"
+crate-type = ["cdylib"]
+
 [dependencies]
 anyhow = "1.0.56"
 base64 = "0.13"
@@ -19,6 +23,8 @@ console-subscriber = "0.1.3"
 env_logger = "0.9"
 log = "0.4.14"
 pretty-hex = "0.2.1"
+pyo3 = { version = "0.16.3", features = ["extension-module"] }
+pyo3-asyncio = { version = "0.16", features = ["tokio-runtime"] }
 smoltcp = "0.8"
 tokio = { version = "1.15", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
@@ -26,4 +32,3 @@ tokio = { version = "1.15", features = ["macros", "net", "rt-multi-thread", "syn
 codegen-units = 1
 lto = true
 opt-level = 3
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["maturin>=0.12,<0.13"]
+build-backend = "maturin"
+
+[project]
+name = "mitmproxy_wireguard"
+requires-python = ">=3.6"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,39 @@
+use pyo3::prelude::*;
+
+
+#[pyclass]
+struct WireguardServer {
+    inner: i32,
+}
+
+#[pymethods]
+impl WireguardServer {
+    fn tcp_send(&self) -> PyResult<i32> {
+        todo!();
+        Ok(42)
+    }
+
+    fn tcp_close(&self) -> PyResult<i32> {
+        todo!();
+        Ok(42)
+    }
+
+    fn stop(&self) -> PyResult<i32> {
+        todo!();
+        Ok(42)
+    }
+}
+
+#[pyfunction]
+fn start_server(py: Python<'_>, host: String, port: u16) -> PyResult<&PyAny> {
+    pyo3_asyncio::tokio::future_into_py(py, async {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        Ok(WireguardServer { inner: 42 })
+    })
+}
+
+#[pymodule]
+fn mitmproxy_wireguard(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(start_server, m)?)?;
+    Ok(())
+}

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,7 +1,7 @@
+use anyhow::Context;
 use std::collections::{HashMap, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
-use anyhow::Context;
 
 use pretty_hex::pretty_hex;
 use smoltcp::iface::{Interface, InterfaceBuilder, SocketHandle};
@@ -36,18 +36,12 @@ impl TcpHandler {
         &mut self,
         mut ip_packet: Ipv4Packet<Vec<u8>>,
     ) -> Result<Vec<Ipv4Packet<Vec<u8>>>, anyhow::Error> {
-        let tcp_packet = TcpPacket::new_checked(
-            ip_packet.payload_mut().to_vec()
-        ).context("invalid TCP packet")?;
+        let tcp_packet = TcpPacket::new_checked(ip_packet.payload_mut().to_vec()).context("invalid TCP packet")?;
 
         let src_ip = IpAddr::V4(Ipv4Addr::from(ip_packet.src_addr()));
         let dst_ip = IpAddr::V4(Ipv4Addr::from(ip_packet.dst_addr()));
 
-        log::debug!(
-            "Outgoing IPv4 TCP packet: {} -> {}",
-            src_ip,
-            dst_ip
-        );
+        log::debug!("Outgoing IPv4 TCP packet: {} -> {}", src_ip, dst_ip);
         log::debug!("{}", pretty_hex(&ip_packet.payload_mut()));
 
         let dst_addr = SocketAddr::new(dst_ip, tcp_packet.dst_port());
@@ -57,8 +51,8 @@ impl TcpHandler {
 
         if syn {
             let mut socket = TcpSocket::new(
-                TcpSocketBuffer::new(vec![0u8; 4096]),
-                TcpSocketBuffer::new(vec![0u8; 4096]),
+                TcpSocketBuffer::new(vec![0u8; 128 * 1024]),
+                TcpSocketBuffer::new(vec![0u8; 128 * 1024]),
             );
 
             socket.set_ack_delay(None);

--- a/test.py
+++ b/test.py
@@ -1,0 +1,16 @@
+import asyncio
+
+import mitmproxy_wireguard
+
+print(f"{dir(mitmproxy_wireguard)=}")
+
+
+async def main():
+    print("main")
+    server = await mitmproxy_wireguard.start_server("", 51820)
+    print(f"{server=}")
+    print(f"{server.send()=}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
See individual commits below.

Some thoughts on the next steps:
 - One thing that's slightly annoying about having multiple smoltcp interfaces is that we need to route 
   ```python
    server.tcp_send(connection_id=42, data=b"...")
    ```
    to the correct smoltcp interface. Maybe it's easier to just use one interface here and map from IPs to peers on the WireGuard side.
- I haven't quite figured out what's the best way to get the raw TCP events out without intertwining everything. I'll keep going on that.

If you want to coordinate on chat, send me an email with what works best for you (ideally Slack, Discord). Alternatively we can stay to mail. :) 