### PR TITLE
Mitigate "TCP channel full" errors

### DIFF
--- a/src/network/task.rs
+++ b/src/network/task.rs
@@ -203,7 +203,7 @@ impl<'a> NetworkTask<'a> {
                     }
                 }
 
-                log::debug!(
+                log::trace!(
                     "TCP connection {}: socket state {}",
                     connection_id,
                     sock.state()

--- a/src/server.rs
+++ b/src/server.rs
@@ -110,12 +110,12 @@ impl Server {
         log::debug!("Initializing WireGuard server ...");
 
         // initialize channels between the WireGuard server and the virtual network device
-        let (wg_to_smol_tx, wg_to_smol_rx) = channel(16);
-        let (smol_to_wg_tx, smol_to_wg_rx) = channel(16);
+        let (wg_to_smol_tx, wg_to_smol_rx) = channel(256);
+        let (smol_to_wg_tx, smol_to_wg_rx) = channel(256);
 
         // initialize channels between the virtual network device and the python interop task
         // - only used to notify of incoming connections and datagrams
-        let (smol_to_py_tx, smol_to_py_rx) = channel(64);
+        let (smol_to_py_tx, smol_to_py_rx) = channel(256);
         // - used to send data and to ask for packets
         // This channel needs to be unbounded because write() is not async.
         let (py_to_smol_tx, py_to_smol_rx) = unbounded_channel();


### PR DESCRIPTION
This PR is an attempt at fixing https://github.com/mitmproxy/mitmproxy/issues/5694:

- First, we now try to consume more than one packet (if available) before iterating over the smoltcp sockets. Iterating over the smoltcp sockets is fast already, but batching makes things even faster.
- Somewhat unrelatedly, I discovered during debugging that we create a second socket for resent SYN packets. We now make sure this doesn't happen anymore.
- Remove a very expensive logging call (see below).
- Finally, we simply increase the channel sizes. The previous settings have been a bit too conservative.

These changes should mitigate the reported problem to the extent that I can reproduce it anymore, but unfortunately is not a complete fix. The bigger pressing problem seems to be that pyo3-log is slow and blocking - the following block takes about 100ms when mitmweb is running under load:
```rust
for _ in 0..100 {
    log::debug!("slow");
}
```

It seems like mitmdump isn't affected, and numbers get much worse once I add more mitmweb WebSocket connections. So there's clearly some work that needs to be done on the Python side as well.