### PR TITLE
expose original source address of WireGuard UDP packets in TcpStream

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -7,7 +7,10 @@ use tokio::sync::oneshot;
 /// Events that are sent by WireGuard to the TCP stack.
 #[derive(Debug)]
 pub enum NetworkEvent {
-    ReceivePacket(IpPacket),
+    ReceivePacket {
+        packet: IpPacket,
+        src_orig: SocketAddr,
+    },
 }
 
 /// Commands that are sent by the TCP stack to WireGuard.
@@ -25,11 +28,13 @@ pub enum TransportEvent {
         connection_id: ConnectionId,
         src_addr: SocketAddr,
         dst_addr: SocketAddr,
+        src_orig: SocketAddr,
     },
     DatagramReceived {
         data: Vec<u8>,
         src_addr: SocketAddr,
         dst_addr: SocketAddr,
+        src_orig: SocketAddr,
     },
 }
 

--- a/src/python/task.rs
+++ b/src/python/task.rs
@@ -55,6 +55,7 @@ impl PyInteropTask {
                                 connection_id,
                                 src_addr,
                                 dst_addr,
+                                src_orig,
                             } => {
                                 let stream = TcpStream {
                                     connection_id,
@@ -62,6 +63,7 @@ impl PyInteropTask {
                                     peername: src_addr,
                                     sockname: self.local_addr,
                                     original_dst: dst_addr,
+                                    original_src: src_orig,
                                     is_closing: false,
                                 };
 
@@ -88,6 +90,7 @@ impl PyInteropTask {
                                 data,
                                 src_addr,
                                 dst_addr,
+                                ..
                             } => {
                                 Python::with_gil(|py| {
                                     let bytes: Py<PyBytes> = PyBytes::new(py, &data).into_py(py);

--- a/src/python/tcp_stream.rs
+++ b/src/python/tcp_stream.rs
@@ -25,6 +25,7 @@ pub struct TcpStream {
     pub(super) peername: SocketAddr,
     pub(super) sockname: SocketAddr,
     pub(super) original_dst: SocketAddr,
+    pub(super) original_src: SocketAddr,
     pub(super) is_closing: bool,
 }
 
@@ -100,7 +101,7 @@ impl TcpStream {
 
     /// Query the TCP stream for details of the underlying network connection.
     ///
-    /// Supported values: `peername`, `sockname`, `original_dst`.
+    /// Supported values: `peername`, `sockname`, `original_dst`, and `original_src`.
     #[args(default = "None")]
     fn get_extra_info(
         &self,
@@ -112,6 +113,7 @@ impl TcpStream {
             ("peername", _) => Ok(socketaddr_to_py(py, self.peername)),
             ("sockname", _) => Ok(socketaddr_to_py(py, self.sockname)),
             ("original_dst", _) => Ok(socketaddr_to_py(py, self.original_dst)),
+            ("original_src", _) => Ok(socketaddr_to_py(py, self.original_src)),
             (_, Some(default)) => Ok(default),
             _ => Err(PyKeyError::new_err(name)),
         }
@@ -119,8 +121,8 @@ impl TcpStream {
 
     fn __repr__(&self) -> String {
         format!(
-            "TcpStream({}, peer={}, sock={}, dst={})",
-            self.connection_id, self.peername, self.sockname, self.original_dst,
+            "TcpStream({}, peer={}, sock={}, src={}, dst={})",
+            self.connection_id, self.peername, self.sockname, self.original_src, self.original_dst,
         )
     }
 }


### PR DESCRIPTION
The source socket of WireGuard UDP packets (i.e. the socket address of the WireGuard client *outside* the WireGuard tunnel) can now be accessed with `TcpStream.get_extra_info("original_src")`.

There's currently no way to do the same for UDP packets, since the callback for received UDP packets only accepts (payload, src_addr, dst_addr) as arguments.